### PR TITLE
Fix STD instruction overwriting register object with numeric value

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -2705,7 +2705,7 @@ class Interpreter {
                 Rd = this.getArgumentValue(1);
                 if (w === 'Y') k = this.getY() + q;
                 else if (w === 'Z') k = this.getZ() + q;
-                this.getDMEM()[k] = Rd;   // (k) <-- Rd
+                this.getDMEM()[k].setValue(Rd);   // (k) <-- Rd
                 this.cycles += 1;
                 break;
             case 'STS':


### PR DESCRIPTION
Without knowing much about the overall structure of the app, it appears that DMEM is a bunch of Register objects. There are certain areas where the objects are overwritten with something like: `this.getDMEM()[k] = Rd`

This overwrites the Register object and eventually the app crashes in `populateRegisters()` because it expects the `.getValue()` function to exist for the members of the array being iterated on.

There are other areas where DMEM is written to directly instead of using `.setValue()` but I did not want to meddle with parts of the code I don't know how to test.