### PR TITLE
Fix bad `current_tok` references

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -836,7 +836,7 @@ class ExpressionEvaluator {
         if (this.expression.length === 0) this.expression_start = this.index;
 
         else if (this.last_tok.getType() === 'INT' && this.tok_type === 'INT' && this.tok_value >= 0) {
-            this.newError(`Cannot evaluate expression on line ${current_tok.getLine()} beginning at position ${this.line[this.expression_start].getStart()}`);
+            this.newError(`Cannot evaluate expression on line ${this.current_tok.getLine()} beginning at position ${this.line[this.expression_start].getStart()}`);
         }
 
         this.expression += this.tok_value;
@@ -1604,7 +1604,7 @@ class Parser {
 
                 // if it's the 3rd last argument (expecting REF)
                 if (this.current_tok.getType() !== 'REF') {
-                    this.newError(`Bad argument \'${current_tok.getValue()}\' on line ${this.line_in_file}.`)
+                    this.newError(`Bad argument \'${this.current_tok.getValue()}\' on line ${this.line_in_file}.`)
                 }
 
                 // Move to next token
@@ -5242,6 +5242,7 @@ class App {
 }
 
 app = new App();
+
 
 
 


### PR DESCRIPTION
In a couple of error messages, code inside template literals was referencing the `current_tok` variable which did not exist, which led to uncaught exceptions in the simulator. This meant it stayed stuck on whatever previous state it was on, with no user-visible error messages. Some example assembly code that reproduces this issue:

```
.section .data
a: .space 0 4

.section .text
.global asm_function

asm_function:
ret

.end
```

The code path with the error is invoked whenever a directive like `.space 0 4` is included which has a missing comma.

Fixed by updating the template to use `this.current_tok` instead.